### PR TITLE
Fix the privatekey loaded to web3

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const toWei = web3.utils.toWei
 const keyFile = ".private-key.txt"
 const contractAddressFile = "contract-address.txt"
 const privateKey = readFileSync(keyFile)
-const account = eth.accounts.privateKeyToAccount(privateKey)
+const account = eth.accounts.privateKeyToAccount(privateKey.toString())
 const address = account.address
 
 const broadcastTransaction = async (rawTx) => {


### PR DESCRIPTION
Hello,

The privateKey loaded on `privateKeyToAccount` is different than the key in the file.

privateKey without a `.toString()` has the EOF stuff in it which is a different key the created one